### PR TITLE
Add function `appendAll()`

### DIFF
--- a/src/font/less/roboto.less
+++ b/src/font/less/roboto.less
@@ -11,6 +11,7 @@
     url('../fonts/roboto/Roboto-Thin.woff') format('woff');
   font-weight: 100;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -20,6 +21,7 @@
     url('../fonts/roboto/Roboto-ThinItalic.woff') format('woff');
   font-weight: 100;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -29,6 +31,7 @@
     url('../fonts/roboto/Roboto-Light.woff') format('woff');
   font-weight: 300;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -38,6 +41,7 @@
     url('../fonts/roboto/Roboto-LightItalic.woff') format('woff');
   font-weight: 300;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -47,6 +51,7 @@
     url('../fonts/roboto/Roboto-Regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -56,6 +61,7 @@
     url('../fonts/roboto/Roboto-RegularItalic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -65,6 +71,7 @@
     url('../fonts/roboto/Roboto-Medium.woff') format('woff');
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -74,6 +81,7 @@
     url('../fonts/roboto/Roboto-MediumItalic.woff') format('woff');
   font-weight: 500;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -83,6 +91,7 @@
     url('../fonts/roboto/Roboto-Bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -92,6 +101,7 @@
     url('../fonts/roboto/Roboto-BoldItalic.woff') format('woff');
   font-weight: 700;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -101,6 +111,7 @@
     url('../fonts/roboto/Roboto-Black.woff') format('woff');
   font-weight: 900;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -110,4 +121,5 @@
     url('../fonts/roboto/Roboto-BlackItalic.woff') format('woff');
   font-weight: 900;
   font-style: italic;
+  font-display: swap;
 }

--- a/src/jq/js/jq.js
+++ b/src/jq/js/jq.js
@@ -1174,7 +1174,12 @@ var $ = (function () {
    * @param newChild {String|Node|NodeList|JQ}
    * @return {JQ}
    */
-  each(['append', 'prepend'], function (nameIndex, name) {
+  /**
+   * appendAll - 在元素内部追加所有参数的内容
+   * @param newChild {String|Node|NodeList|JQ}
+   * @return {JQ}
+   */
+  each(['append', 'prepend', 'appendAll'], function (nameIndex, name) {
     $.fn[name] = function (newChild) {
       var newChilds;
       var copyByClone = this.length > 1;
@@ -1183,13 +1188,18 @@ var $ = (function () {
         var tempDiv = document.createElement('div');
         tempDiv.innerHTML = newChild;
         newChilds = [].slice.call(tempDiv.childNodes);
-      } else {
+      } else if (nameIndex !== 2) {
         newChilds = $(newChild).get();
       }
 
       if (nameIndex === 1) {
         // prepend
         newChilds.reverse();
+      }
+
+      if (nameIndex === 2) {
+        // appendAll
+        newChilds = Array.prototype.flatMap.call(arguments, arg => $(arg).get());
       }
 
       return this.each(function (i, _this) {
@@ -1199,8 +1209,8 @@ var $ = (function () {
             child = child.cloneNode(true);
           }
 
-          if (nameIndex === 0) {
-            // append
+          if (nameIndex !== 1) {
+            // append & appendAll
             _this.appendChild(child);
           } else {
             // prepend


### PR DESCRIPTION
Appending all arguments of the function to the selected element, which behaves like the `ParentNode.append()` function in JavaScript API: https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append

Not tested for all types of arguments but works for JQ and Node objects. Implementation can be improved using a totally different approach by modifying the core JQ function.

May also implement `prependAll()` and other similar functions.