### PR TITLE
补充添加Collapse相关组件到`HTMLElementTagNameMap`

### DIFF
--- a/packages/mdui/src/components/collapse/collapse-item.ts
+++ b/packages/mdui/src/components/collapse/collapse-item.ts
@@ -147,3 +147,9 @@ export class CollapseItem extends LitElement {
     );
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'mdui-collapse-item': CollapseItem;
+  }
+}

--- a/packages/mdui/src/components/collapse/collapse.ts
+++ b/packages/mdui/src/components/collapse/collapse.ts
@@ -233,3 +233,9 @@ export class Collapse extends LitElement {
     });
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'mdui-collapse': Collapse;
+  }
+}


### PR DESCRIPTION
`mdui-collapse`与`mdui-collapse-item`似乎忘记写进`global.HTMLElementTagNameMap`了