### PR TITLE
为根目录的packages.json添加name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@mdui/monorepo",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
虽然根目录的包不被发布，但是没有名字的包无法通过`pnpm i git+ssh://git@github.com:zdhxiong/mdui.git`这样的命令安装，造成了诸多不便。
虽然这样的用例非常少，但是将根目录的包命名为`@mdui/monorepo`，可以几乎无成本地解决这个(目前我经过大量搜索)**没有其他解决方法**的问题，望采纳。