### PR TITLE
Allow setting aria-label on mdui-text-field's input element

### DIFF
--- a/packages/mdui/src/components/text-field/index.ts
+++ b/packages/mdui/src/components/text-field/index.ts
@@ -393,6 +393,12 @@ export class TextField
   public autocomplete?: string;
 
   /**
+   * `input` 元素的 `aria-label` 属性
+   */
+  @property({ reflect: true })
+  public ariaLabel?: string;
+
+  /**
    * `input` 元素的 `enterkeyhint` 属性，用于定制虚拟键盘上的 Enter 键的显示文本或图标。具体显示效果取决于用户使用的设备和语言。可选值包括：
    *
    * * `enter`：插入新行
@@ -1027,6 +1033,7 @@ export class TextField
         this.type === 'password' ? 'off' : this.autocapitalize,
       )}
       autocomplete=${this.autocomplete}
+      aria-label=${ifDefined(this.ariaLabel)}
       autocorrect=${ifDefined(
         this.type === 'password' ? 'off' : this.autocorrect,
       )}


### PR DESCRIPTION
I increased my lighthouse accessibility score by allowing to set aria-label on the input element of the mdui-textfield. It is related to accessibility best practices to make navigation on the internet easier for people who use screen readers.