### PR TITLE
Fix mdui-icon not rendering correctly when using browsers built-in translators

### DIFF
--- a/packages/mdui/src/components/icon/index.ts
+++ b/packages/mdui/src/components/icon/index.ts
@@ -50,6 +50,7 @@ export class Icon extends MduiElement<IconEventMap> {
         ]);
 
         return html`<span
+          translate="no"
           style=${styleMap({ fontFamily: familyMap.get(variant) })}
         >
           ${name}


### PR DESCRIPTION
Fixes #365 