### PR TITLE
disable autoCloseDelay when SnackBar has an action or is closeable

### DIFF
--- a/docs/en/components/snackbar.md
+++ b/docs/en/components/snackbar.md
@@ -192,6 +192,7 @@ The `message-line` attribute limits the number of lines in the message text, wit
 ### Auto Close Delay {#example-auto-close-delay}
 
 The `auto-close-delay` attribute sets the delay for automatic closure, in milliseconds. The default is `5000` milliseconds.
+Note: Following the guidelines of Material Design 3, this automatic closure is disabled when either `action` is defined or `closeable` is enabled.
 
 ```html,example,expandable,playgroundId=383
 <mdui-snackbar auto-close-delay="2000" class="example-close-delay">Photo archived</mdui-snackbar>

--- a/docs/zh-cn/components/snackbar.md
+++ b/docs/zh-cn/components/snackbar.md
@@ -192,6 +192,7 @@ import type { Snackbar } from 'mdui/components/snackbar.js';
 ### 自动关闭延时 {#example-auto-close-delay}
 
 可以使用 `auto-close-delay` 属性来设置自动关闭的延时，单位为毫秒。默认值为 5000 毫秒。
+注意： 根据 Material Design 3 的指南，当定义了 `action` 或启用了 `closeable` 时，自动关闭将被禁用。
 
 ```html,example,expandable,playgroundId=383
 <mdui-snackbar auto-close-delay="2000" class="example-close-delay">Photo archived</mdui-snackbar>

--- a/packages/mdui/src/components/snackbar/index.ts
+++ b/packages/mdui/src/components/snackbar/index.ts
@@ -189,7 +189,7 @@ export class Snackbar extends MduiElement<SnackbarEventMap> {
       }
 
       window.clearTimeout(this.closeTimeout);
-      if (this.autoCloseDelay) {
+      if (this.autoCloseDelay && !this.action && !this.closeable) {
         this.closeTimeout = window.setTimeout(() => {
           this.open = false;
         }, this.autoCloseDelay);


### PR DESCRIPTION
Material Design 3 guidelines state that the snackbars with actions should remain on screen until the user interacts with them. This PR disables `autoCloseDelay` when an action is present to align the guidelines.


Reference:
https://m3.material.io/components/snackbar/guidelines#602f8f08-c391-48c8-b5f6-7d99edf3cbb4
https://m3.material.io/components/snackbar/accessibility#be58081b-a688-411f-83a7-f77e4873bd7d