### PR TITLE
Enhance indeterminate progress animation to better match Material Design

### DIFF
--- a/packages/mdui/src/components/linear-progress/style.less
+++ b/packages/mdui/src/components/linear-progress/style.less
@@ -27,7 +27,8 @@
     bottom: 0;
     left: 0;
     background-color: inherit;
-    animation: mdui-comp-progress-indeterminate 2s var(--mdui-motion-easing-linear) infinite;
+    animation: mdui-comp-progress-indeterminate 2.1s
+      cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
     content: " ";
   }
 
@@ -37,46 +38,43 @@
     bottom: 0;
     left: 0;
     background-color: inherit;
-    animation: mdui-comp-progress-indeterminate-short 2s var(--mdui-motion-easing-linear) infinite;
+    animation: mdui-comp-progress-indeterminate-short 2.1s
+      cubic-bezier(0.165, 0.84, 0.44, 1) infinite;
+    animation-delay: 1.15s;
     content: " ";
   }
 }
 
 @keyframes mdui-comp-progress-indeterminate {
   0% {
-    left: 0;
-    width: 0;
+    left: -35%;
+    right: 100%;
   }
 
-  50% {
-    left: 30%;
-    width: 70%;
-  }
-
-  75% {
+  60% {
     left: 100%;
-    width: 0;
+    right: -90%;
+  }
+
+  100% {
+    left: 100%;
+    right: -90%;
   }
 }
 
 @keyframes mdui-comp-progress-indeterminate-short {
   0% {
-    left: 0;
-    width: 0;
+    left: -200%;
+    right: 100%;
   }
 
-  50% {
-    left: 0;
-    width: 0;
-  }
-
-  75% {
-    left: 0;
-    width: 25%;
+  60% {
+    left: 107%;
+    right: -8%;
   }
 
   100% {
-    left: 100%;
-    width: 0;
+    left: 107%;
+    right: -8%;
   }
 }


### PR DESCRIPTION
Previously, the animation timing was using the generic `--mdui-motion-easing-linear (cubic-bezier(0, 0, 1, 1))`, which resulted in a motion that felt less natural compared to the expected Material Design behavior.
This change replaces it with a dedicated `cubic-bezier` timing curve specifically tuned for indeterminate progress animations.

**Here's some demo:**

| Before | After |
|---|---|
| ![chrome_F4w1EwXoim](https://github.com/user-attachments/assets/0f316b3f-e6ea-499b-b9ee-7278c55a2e5c) | ![chrome_2Wn0CoTuiW](https://github.com/user-attachments/assets/b39d87e7-7b98-4273-92b5-a6e87725cb48) |

**From [Material Web](https://material-web.dev/components/progress/#linear-progress)**

![chrome_agS4zaHCWN](https://github.com/user-attachments/assets/4dad2c1d-a8f0-46e8-8a18-af1703697629)
