### PR TITLE
Refactor JSX types to include a reference to instance type

### DIFF
--- a/packages/mdui/package.json
+++ b/packages/mdui/package.json
@@ -18,6 +18,7 @@
     "html-data.{en,zh-cn}.json",
     "jq.{js,d.ts}",
     "jsx.{en,zh-cn}.d.ts",
+    "jsx2.{en,zh-cn}.d.ts",
     "LICENSE",
     "mdui.css",
     "mdui.{js,d.ts}",

--- a/scripts/common/build/jsx-types.ts
+++ b/scripts/common/build/jsx-types.ts
@@ -22,7 +22,8 @@ export const buildJSXTypes = (metadataPath: string, packageFolder: string) => {
   i18nLanguages.forEach((language) => {
     const i18nData = getI18nData(language);
     const jsxElements: {
-      name: string;
+      tagName: string;
+      className: string;
       docUrl: string;
       description: string;
       attributes: {
@@ -37,11 +38,13 @@ export const buildJSXTypes = (metadataPath: string, packageFolder: string) => {
     const components = getAllComponents(metadataPath);
     components.map((component) => {
       const tagName = component.tagName;
+      const className = component.name;
       const docUrl = getDocUrlByTagName(tagName, language);
       const hasMultipleComponents = isDocHasMultipleComponents(tagName);
 
       jsxElements.push({
-        name: tagName,
+        tagName: tagName,
+        className: className,
         docUrl,
         description: handleDescription(
           i18nData[tagName].summary,
@@ -54,9 +57,8 @@ export const buildJSXTypes = (metadataPath: string, packageFolder: string) => {
             .filter((v) => v && v !== 'undefined') // 移除 undefined
             .map((v) => v.replace(/\/\*([\s\S]*?)\*\//, '').trim()); // 移除枚举类型枚举项的注释
 
-          const componentName = `${
-            hasMultipleComponents ? tagName.slice(5) + '-' : ''
-          }`;
+          const componentName = `${hasMultipleComponents ? tagName.slice(5) + '-' : ''
+            }`;
 
           return {
             name: attr.attribute!,
@@ -82,33 +84,71 @@ declare global {
     namespace JSX {
       interface IntrinsicElements {
         ${jsxElements
-          .map(
-            (element) => `/**
+        .map(
+          (element) => `/**
         * ${element.description.split('\n').join('\n       * ')}
         * @see ${element.docUrl}
         */
-        '${element.name}': {
+        '${element.tagName}': {
           ${element.attributes
-            .map(
-              (attribute) => `/**
+              .map(
+                (attribute) => `/**
           * ${attribute.description.split('\n').join('\n         * ')}
           * @see ${attribute.docUrl}
           */
           '${attribute.name}'?: ${attribute.type};`,
-            )
-            .join('\n        ')}
+              )
+              .join('\n        ')}
         } & HTMLElementProps;`,
-          )
-          .join('\n      ')}
+        )
+        .join('\n      ')}
       }
     }
   }
 }
 `;
 
+
+    const jsx2Type = `
+import { JQ } from '@mdui/jq';
+import * as mdui from "./mdui.js";
+
+export interface IntrinsicAttributes<T> {
+  ref: (e: T | null) => void;
+}
+
+export interface IntrinsicElements {
+  ${jsxElements
+        .map(
+          (element) => `/**
+  * ${element.description.split('\n').join('\n  * ')}
+  * @see ${element.docUrl}
+  */
+  '${element.tagName}': {
+    ${element.attributes
+              .map(
+                (attribute) => `/**
+    * ${attribute.description.split('\n').join('\n    * ')}
+    * @see ${attribute.docUrl}
+    */
+    '${attribute.name}'?: ${attribute.type};`,
+              )
+              .join('\n    ')}
+  } & IntrinsicAttributes<mdui.${element.className}>;`,
+        )
+        .join('\n  ')}
+}
+`;
+
     fs.writeFileSync(
       path.resolve(`./packages/${packageFolder}/jsx.${language}.d.ts`),
       jsxType,
+      'utf8',
+    );
+
+    fs.writeFileSync(
+      path.resolve(`./packages/${packageFolder}/jsx2.${language}.d.ts`),
+      jsx2Type,
       'utf8',
     );
   });

--- a/scripts/common/build/jsx-types.ts
+++ b/scripts/common/build/jsx-types.ts
@@ -113,9 +113,7 @@ declare global {
 import { JQ } from '@mdui/jq';
 import * as mdui from "./mdui.js";
 
-export interface IntrinsicAttributes<T> {
-  ref: (e: T | null) => void;
-}
+export interface IntrinsicAttributes<T> { }
 
 export interface IntrinsicElements {
   ${jsxElements


### PR DESCRIPTION
This generates a second jsx.*.d.ts which does two things.

- Export the types instead of putting them on global
- Include the class instance type in the interface type parameter

```ts

import { JQ } from '@mdui/jq';
import * as mdui from "./mdui.js";

export interface IntrinsicAttributes<T> { }

export interface IntrinsicElements {
  "mdui-avatar": {
    "value": string;
  } & IntrinsicAttributes<mdui.Avatar>
}
```

This allows the type declarations to be used with any custom JSX typing system or any other attribute based types.

```ts
import type * as MDUI from "mdui/jsx2.en.d.ts";
declare global {
  export interface CustomElements extends MDUI.IntrinsicElements { }
}
declare module "mdui/jsx2.en.d.ts" {
  // extend IntrinsicAttributes with my own HTMLAttributes typing
  export interface IntrinsicAttributes<T extends Element> extends JSX.SimpleAttrs<{}, T> { }
}

const test = <mdui-avatar ref={e => e}></mdui-avatar>
```

It might be surprising that this works, but since multiple interface declarations are combined, TypeScript doesn't care where they're declared and just combines them all, allowing the consumer of a library to fill in the missing definitions. All declarations of an interface must have identical type parameters, allowing them to transfer type information.

If the instance type was the only thing I needed, I could match this to `HTMLElementTagNameMap`. But I wanted to use my own list of standard attributes rather than the ones from React, because they aren't quite the same and I'm not using React. I'm also using attributes specifically, not properties. 