### PR TITLE
feat: add image-select component

### DIFF
--- a/demos/components/image-select.html
+++ b/demos/components/image-select.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh">
+
+<head>
+  <title>Image Select</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
+    rel="stylesheet">
+  <style>
+    body {
+      font-family: Roboto;
+      padding: 24px;
+    }
+
+    section {
+      margin-bottom: 32px;
+    }
+
+    .standalone mdui-image-select {
+      width: 200px;
+      height: 200px;
+      margin-right: 16px;
+    }
+
+    mdui-image-select-group {
+      max-width: 640px;
+    }
+
+    mdui-image-select {
+      aspect-ratio: 1;
+    }
+
+    #output {
+      margin-top: 16px;
+      padding: 12px;
+      background: #f5f5f5;
+      border-radius: 8px;
+      font-family: monospace;
+    }
+  </style>
+  <script type="module">
+    import '../../packages/mdui/mdui.css';
+    import '../../packages/mdui/components/image-select.js';
+    import '../../packages/mdui/components/image-select-group.js';
+
+    // Log group value changes
+    document.querySelector('#group-multiple').addEventListener('change', (e) => {
+      document.querySelector('#output-multiple').textContent =
+        'value: ' + JSON.stringify(e.target.value);
+    });
+
+    document.querySelector('#group-single').addEventListener('change', (e) => {
+      document.querySelector('#output-single').textContent =
+        'value: ' + JSON.stringify(e.target.value);
+    });
+  </script>
+</head>
+
+<body>
+  <main>
+    <h1>Image Select</h1>
+
+    <section>
+      <h2>Standalone</h2>
+      <div class="standalone" style="display: flex; flex-wrap: wrap; gap: 16px;">
+        <mdui-image-select
+          src="https://picsum.photos/seed/a/400/400"
+          value="1"
+        ></mdui-image-select>
+        <mdui-image-select
+          src="https://picsum.photos/seed/b/400/400"
+          value="2"
+          selected
+        ></mdui-image-select>
+        <mdui-image-select
+          src="https://picsum.photos/seed/c/400/400"
+          value="3"
+          disabled
+        ></mdui-image-select>
+      </div>
+    </section>
+
+    <section>
+      <h2>Group - Multiple Selection</h2>
+      <mdui-image-select-group id="group-multiple" selects="multiple">
+        <mdui-image-select src="https://picsum.photos/seed/1/400/400" value="1"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/2/400/400" value="2"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/3/400/400" value="3"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/4/400/400" value="4"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/5/400/400" value="5"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/6/400/400" value="6"></mdui-image-select>
+      </mdui-image-select-group>
+      <div id="output-multiple" class="output">value: []</div>
+    </section>
+
+    <section>
+      <h2>Group - Single Selection</h2>
+      <mdui-image-select-group id="group-single" selects="single">
+        <mdui-image-select src="https://picsum.photos/seed/7/400/400" value="a"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/8/400/400" value="b"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/9/400/400" value="c"></mdui-image-select>
+      </mdui-image-select-group>
+      <div id="output-single" class="output">value: ""</div>
+    </section>
+
+    <section>
+      <h2>Group - 4 Columns</h2>
+      <mdui-image-select-group selects="multiple" style="--columns: 4; --gap: 4px;">
+        <mdui-image-select src="https://picsum.photos/seed/10/400/400" value="1"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/11/400/400" value="2"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/12/400/400" value="3"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/13/400/400" value="4"></mdui-image-select>
+      </mdui-image-select-group>
+    </section>
+
+    <section>
+      <h2>Group - Disabled</h2>
+      <mdui-image-select-group selects="multiple" disabled>
+        <mdui-image-select src="https://picsum.photos/seed/14/400/400" value="1"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/15/400/400" value="2"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/16/400/400" value="3"></mdui-image-select>
+      </mdui-image-select-group>
+    </section>
+
+    <section class="mdui-theme-dark" style="background: #1c1b1f; padding: 24px; border-radius: 16px;">
+      <h2 style="color: white;">Dark Theme</h2>
+      <mdui-image-select-group selects="multiple">
+        <mdui-image-select src="https://picsum.photos/seed/17/400/400" value="1"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/18/400/400" value="2"></mdui-image-select>
+        <mdui-image-select src="https://picsum.photos/seed/19/400/400" value="3"></mdui-image-select>
+      </mdui-image-select-group>
+    </section>
+  </main>
+</body>
+
+</html>

--- a/demos/index.html
+++ b/demos/index.html
@@ -37,6 +37,7 @@
       <mdui-list-item href="./components/select.html">Select</mdui-list-item>
       <mdui-list-item href="./components/slider.html">Slider & Range Slider</mdui-list-item>
       <mdui-list-item href="./components/card.html">Card</mdui-list-item>
+      <mdui-list-item href="./components/image-select.html">Image Select</mdui-list-item>
       <mdui-list-item href="./components/dialog.html">Dialog</mdui-list-item>
       <mdui-list-item href="./components/icon.html">Icon</mdui-list-item>
       <mdui-list-item href="./components/badge.html">Badge</mdui-list-item>

--- a/docs/en.json
+++ b/docs/en.json
@@ -205,6 +205,7 @@
       "tagNames": [
         "mdui-card",
         "mdui-checkbox",
+        "mdui-image-select",
         "mdui-list-item",
         "mdui-menu-item",
         "mdui-navigation-bar-item",
@@ -862,6 +863,82 @@
     },
     "slots": {
       "": "The SVG icon content."
+    }
+  },
+  "mdui-image-select": {
+    "summary": "Image Select Component. Can be used with `<mdui-image-select-group>`.\n\n```html\n<mdui-image-select src=\"https://example.com/image.jpg\" value=\"1\"></mdui-image-select>\n```",
+    "properties": {
+      "src": {
+        "description": "The URL of the image."
+      },
+      "alt": {
+        "description": "Alternative text description for the image."
+      },
+      "fit": {
+        "description": "Defines how the image fits within its container, same as the native `object-fit` property. Possible values:\n\n* `contain`: Scales the image to maintain its aspect ratio while fitting within the container.\n* `cover`: Scales the image to maintain its aspect ratio while filling the container. Parts of the image may be clipped.\n* `fill`: Stretches the image to fill the container without maintaining its aspect ratio.\n* `none`: Keeps the image at its original size without scaling or stretching.\n* `scale-down`: Sizes the image as the smaller of `none` or `contain`.",
+        "enum": {
+          "contain": "Scales the image to maintain its aspect ratio while fitting within the container.",
+          "cover": "Scales the image to maintain its aspect ratio while filling the container. Parts of the image may be clipped.",
+          "fill": "Stretches the image to fill the container without maintaining its aspect ratio.",
+          "none": "Keeps the image at its original size without scaling or stretching.",
+          "scale-down": "Sizes the image as the smaller of `none` or `contain`."
+        }
+      },
+      "selected": {
+        "description": "Whether the item is selected."
+      },
+      "disabled": {
+        "description": "Whether the item is disabled."
+      },
+      "value": {
+        "description": "The value of the image select item, used by `<mdui-image-select-group>`."
+      },
+      "groupDisabled": {
+        "description": "Whether the item is disabled by the group component (internal use)."
+      }
+    },
+    "events": {
+      "focus": "Emitted when the component gains focus.",
+      "blur": "Emitted when the component loses focus.",
+      "change": "Emitted when the selected state changes."
+    },
+    "slots": {
+      "": "Custom image content. Can be an `<img>` element or other content."
+    },
+    "cssParts": {
+      "image": "The internal `<img>` element.",
+      "indicator": "The selection indicator icon."
+    },
+    "cssProperties": {
+      "--shape-corner": "The corner radius of the component. You can use a specific pixel value, but it is recommended to reference design tokens."
+    }
+  },
+  "mdui-image-select-group": {
+    "summary": "Image Select Group Component. Used with `<mdui-image-select>` components.\n\n```html\n<mdui-image-select-group selects=\"multiple\">\n..<mdui-image-select src=\"image1.jpg\" value=\"1\"></mdui-image-select>\n..<mdui-image-select src=\"image2.jpg\" value=\"2\"></mdui-image-select>\n..<mdui-image-select src=\"image3.jpg\" value=\"3\"></mdui-image-select>\n</mdui-image-select-group>\n```",
+    "properties": {
+      "selects": {
+        "description": "The selection mode. Possible values:\n\n* `single`: Single selection.\n* `multiple`: Multiple selection.",
+        "enum": {
+          "single": "Single selection.",
+          "multiple": "Multiple selection."
+        }
+      },
+      "disabled": {
+        "description": "Whether all items are disabled."
+      },
+      "value": {
+        "description": "The value of the currently selected `<mdui-image-select>` item(s).\n\nWhen `selects=\"single\"`, this is a string. When `selects=\"multiple\"`, this is an array of strings."
+      }
+    },
+    "events": {
+      "change": "Emitted when the selected value changes."
+    },
+    "slots": {
+      "": "`<mdui-image-select>` components."
+    },
+    "cssProperties": {
+      "--columns": "The number of grid columns. Defaults to `3`.",
+      "--gap": "The grid gap. Defaults to `0.5rem`."
     }
   },
   "mdui-layout": {

--- a/docs/en/components/image-select.md
+++ b/docs/en/components/image-select.md
@@ -1,0 +1,110 @@
+# Image Select Component
+
+The image select component allows users to select one or more images from a collection. It displays a check indicator when selected. Use it with `<mdui-image-select-group>` for managing selection state across multiple items.
+
+## Usage {#usage}
+
+Import the component:
+
+```js
+import 'mdui/components/image-select.js';
+import 'mdui/components/image-select-group.js';
+```
+
+Import the TypeScript type:
+
+```ts
+import type { ImageSelect } from 'mdui/components/image-select.js';
+import type { ImageSelectGroup } from 'mdui/components/image-select-group.js';
+```
+
+Example:
+
+```html,example
+<mdui-image-select-group selects="multiple">
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+</mdui-image-select-group>
+```
+
+## Examples {#examples}
+
+### Standalone Usage {#example-standalone}
+
+The `<mdui-image-select>` component can be used independently without a group. Click to toggle the selected state.
+
+```html,example,expandable
+<mdui-image-select src="https://via.placeholder.com/200" style="width: 200px; height: 200px"></mdui-image-select>
+```
+
+### Multiple Selection {#example-selects-multiple}
+
+Set the `selects` attribute of `<mdui-image-select-group>` to `multiple` (default) to enable multiple selection mode. In this mode, the `value` property of `<mdui-image-select-group>` is an array of the `value` properties of the currently selected items.
+
+Note: In multiple selection mode, the `value` property is an array and can only be read and set through JavaScript.
+
+```html,example,expandable
+<mdui-image-select-group selects="multiple">
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+</mdui-image-select-group>
+```
+
+### Single Selection {#example-selects-single}
+
+Set the `selects` attribute to `single` for single selection mode. In this mode, the `value` property of `<mdui-image-select-group>` reflects the `value` of the currently selected item.
+
+```html,example,expandable
+<mdui-image-select-group selects="single">
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+</mdui-image-select-group>
+```
+
+### Grid Columns {#example-columns}
+
+Use the `--columns` CSS custom property on `<mdui-image-select-group>` to control the number of grid columns. The default is `3`.
+
+```html,example,expandable
+<mdui-image-select-group selects="multiple" style="--columns: 4">
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="4"></mdui-image-select>
+</mdui-image-select-group>
+```
+
+### Image Fit {#example-fit}
+
+Use the `fit` attribute to control how the image fits within the container. Possible values are `contain`, `cover` (default), `fill`, `none`, and `scale-down`.
+
+```html,example,expandable
+<mdui-image-select src="https://via.placeholder.com/400x200" fit="contain" style="width: 200px; height: 200px"></mdui-image-select>
+<mdui-image-select src="https://via.placeholder.com/400x200" fit="cover" style="width: 200px; height: 200px"></mdui-image-select>
+<mdui-image-select src="https://via.placeholder.com/400x200" fit="fill" style="width: 200px; height: 200px"></mdui-image-select>
+```
+
+### Custom Content {#example-slot}
+
+Use the default slot to provide custom content instead of the `src` attribute.
+
+```html,example,expandable
+<mdui-image-select style="width: 200px; height: 200px">
+  <img src="https://via.placeholder.com/200" alt="Custom image" style="width: 100%; height: 100%; object-fit: cover" />
+</mdui-image-select>
+```
+
+### Disabled State {#example-disabled}
+
+Add the `disabled` attribute to `<mdui-image-select-group>` to disable all items, or add it to individual `<mdui-image-select>` elements to disable specific items.
+
+```html,example,expandable
+<mdui-image-select-group selects="multiple" disabled>
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+</mdui-image-select-group>
+```

--- a/docs/zh-cn.json
+++ b/docs/zh-cn.json
@@ -205,6 +205,7 @@
       "tagNames": [
         "mdui-card",
         "mdui-checkbox",
+        "mdui-image-select",
         "mdui-list-item",
         "mdui-menu-item",
         "mdui-navigation-bar-item",
@@ -862,6 +863,82 @@
     },
     "slots": {
       "": "`svg` 图标的内容"
+    }
+  },
+  "mdui-image-select": {
+    "summary": "图片选择组件。可配合 `<mdui-image-select-group>` 组件使用\n\n```html\n<mdui-image-select src=\"https://example.com/image.jpg\" value=\"1\"></mdui-image-select>\n```",
+    "properties": {
+      "src": {
+        "description": "图片的 URL 地址"
+      },
+      "alt": {
+        "description": "图片的替代文本描述"
+      },
+      "fit": {
+        "description": "图片如何适应容器框，与原生的 `object-fit` 属性相同。可选值包括：\n\n* `contain`：保持图片原有尺寸比例，内容会被等比例缩放\n* `cover`：保持图片原有尺寸比例，但部分内容可能被剪切\n* `fill`：不保持图片原有尺寸比例，内容会被拉伸以填充整个容器\n* `none`：保留图片原有尺寸，内容不会被缩放或拉伸\n* `scale-down`：保持图片原有尺寸比例，内容尺寸与 `none` 或 `contain` 中较小的一个相同",
+        "enum": {
+          "contain": "保持图片原有尺寸比例，内容会被等比例缩放",
+          "cover": "保持图片原有尺寸比例，但部分内容可能被剪切",
+          "fill": "不保持图片原有尺寸比例，内容会被拉伸以填充整个容器",
+          "none": "保留图片原有尺寸，内容不会被缩放或拉伸",
+          "scale-down": "保持图片原有尺寸比例，内容尺寸与 `none` 或 `contain` 中较小的一个相同"
+        }
+      },
+      "selected": {
+        "description": "是否为选中状态"
+      },
+      "disabled": {
+        "description": "是否为禁用状态"
+      },
+      "value": {
+        "description": "图片选择的值，将被 `<mdui-image-select-group>` 使用"
+      },
+      "groupDisabled": {
+        "description": "是否被 group 组件禁用（内部使用）"
+      }
+    },
+    "events": {
+      "focus": "获得焦点时触发",
+      "blur": "失去焦点时触发",
+      "change": "选中状态变更时触发"
+    },
+    "slots": {
+      "": "自定义图片内容，可以为 `<img>` 元素或其他内容"
+    },
+    "cssParts": {
+      "image": "组件内部的 `<img>` 元素",
+      "indicator": "选中状态的指示器图标"
+    },
+    "cssProperties": {
+      "--shape-corner": "组件的圆角大小。可以指定一个具体的像素值；但更推荐引用设计令牌"
+    }
+  },
+  "mdui-image-select-group": {
+    "summary": "图片选择组组件。需配合 `<mdui-image-select>` 组件使用\n\n```html\n<mdui-image-select-group selects=\"multiple\">\n..<mdui-image-select src=\"image1.jpg\" value=\"1\"></mdui-image-select>\n..<mdui-image-select src=\"image2.jpg\" value=\"2\"></mdui-image-select>\n..<mdui-image-select src=\"image3.jpg\" value=\"3\"></mdui-image-select>\n</mdui-image-select-group>\n```",
+    "properties": {
+      "selects": {
+        "description": "选择模式。可选值包括：\n\n* `single`：单选\n* `multiple`：多选",
+        "enum": {
+          "single": "单选",
+          "multiple": "多选"
+        }
+      },
+      "disabled": {
+        "description": "是否为禁用状态"
+      },
+      "value": {
+        "description": "当前选中的 `<mdui-image-select>` 的值。\n\n在 `selects=\"single\"` 时为字符串，在 `selects=\"multiple\"` 时为字符串数组。"
+      }
+    },
+    "events": {
+      "change": "选中的值变更时触发"
+    },
+    "slots": {
+      "": "`<mdui-image-select>` 组件"
+    },
+    "cssProperties": {
+      "--columns": "网格列数。默认为 `3`",
+      "--gap": "网格间距。默认为 `0.5rem`"
     }
   },
   "mdui-layout": {

--- a/docs/zh-cn/components/image-select.md
+++ b/docs/zh-cn/components/image-select.md
@@ -1,0 +1,110 @@
+# 图片选择组件 ImageSelect
+
+图片选择组件允许用户从一组图片中选择一个或多个。选中时会显示一个勾选指示器。可配合 `<mdui-image-select-group>` 组件使用，以管理多个项目的选中状态。
+
+## 使用方法 {#usage}
+
+按需导入组件：
+
+```js
+import 'mdui/components/image-select.js';
+import 'mdui/components/image-select-group.js';
+```
+
+按需导入组件的 TypeScript 类型：
+
+```ts
+import type { ImageSelect } from 'mdui/components/image-select.js';
+import type { ImageSelectGroup } from 'mdui/components/image-select-group.js';
+```
+
+使用示例：
+
+```html,example
+<mdui-image-select-group selects="multiple">
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+</mdui-image-select-group>
+```
+
+## 示例 {#examples}
+
+### 独立使用 {#example-standalone}
+
+`<mdui-image-select>` 组件可以独立使用，不需要放在组中。点击即可切换选中状态。
+
+```html,example,expandable
+<mdui-image-select src="https://via.placeholder.com/200" style="width: 200px; height: 200px"></mdui-image-select>
+```
+
+### 多选模式 {#example-selects-multiple}
+
+在 `<mdui-image-select-group>` 元素上指定 `selects` 属性为 `multiple`（默认值），可以实现多选模式。此时 `<mdui-image-select-group>` 的 `value` 属性值为当前选中的 `<mdui-image-select>` 的 `value` 属性的值组成的数组。
+
+注意：在多选模式下，`<mdui-image-select-group>` 的 `value` 属性值为数组，只能通过 JavaScript 属性来读取和设置该值。
+
+```html,example,expandable
+<mdui-image-select-group selects="multiple">
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+</mdui-image-select-group>
+```
+
+### 单选模式 {#example-selects-single}
+
+在 `<mdui-image-select-group>` 元素上指定 `selects` 属性为 `single`，可以实现单选模式。此时 `<mdui-image-select-group>` 的 `value` 属性值即为当前选中的 `<mdui-image-select>` 的 `value` 属性的值。
+
+```html,example,expandable
+<mdui-image-select-group selects="single">
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+</mdui-image-select-group>
+```
+
+### 网格列数 {#example-columns}
+
+在 `<mdui-image-select-group>` 上使用 `--columns` CSS 自定义属性来控制网格列数。默认值为 `3`。
+
+```html,example,expandable
+<mdui-image-select-group selects="multiple" style="--columns: 4">
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="4"></mdui-image-select>
+</mdui-image-select-group>
+```
+
+### 图片适应方式 {#example-fit}
+
+使用 `fit` 属性来控制图片在容器中的适应方式。可选值为 `contain`、`cover`（默认）、`fill`、`none` 和 `scale-down`。
+
+```html,example,expandable
+<mdui-image-select src="https://via.placeholder.com/400x200" fit="contain" style="width: 200px; height: 200px"></mdui-image-select>
+<mdui-image-select src="https://via.placeholder.com/400x200" fit="cover" style="width: 200px; height: 200px"></mdui-image-select>
+<mdui-image-select src="https://via.placeholder.com/400x200" fit="fill" style="width: 200px; height: 200px"></mdui-image-select>
+```
+
+### 自定义内容 {#example-slot}
+
+使用默认 slot 来提供自定义内容，代替 `src` 属性。
+
+```html,example,expandable
+<mdui-image-select style="width: 200px; height: 200px">
+  <img src="https://via.placeholder.com/200" alt="自定义图片" style="width: 100%; height: 100%; object-fit: cover" />
+</mdui-image-select>
+```
+
+### 禁用状态 {#example-disabled}
+
+在 `<mdui-image-select-group>` 元素上添加 `disabled` 属性可以禁用所有项目，或在单个 `<mdui-image-select>` 元素上添加 `disabled` 属性可以禁用特定项目。
+
+```html,example,expandable
+<mdui-image-select-group selects="multiple" disabled>
+  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
+  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
+</mdui-image-select-group>
+```

--- a/packages/mdui/src/components/image-select-group.ts
+++ b/packages/mdui/src/components/image-select-group.ts
@@ -1,0 +1,1 @@
+export * from './image-select/image-select-group.js';

--- a/packages/mdui/src/components/image-select.ts
+++ b/packages/mdui/src/components/image-select.ts
@@ -1,0 +1,1 @@
+export * from './image-select/index.js';

--- a/packages/mdui/src/components/image-select/image-select-group-style.less
+++ b/packages/mdui/src/components/image-select/image-select-group-style.less
@@ -1,0 +1,8 @@
+:host {
+  --columns: 3;
+  --gap: 0.5rem;
+
+  display: grid;
+  grid-template-columns: repeat(var(--columns), 1fr);
+  gap: var(--gap);
+}

--- a/packages/mdui/src/components/image-select/image-select-group.ts
+++ b/packages/mdui/src/components/image-select/image-select-group.ts
@@ -1,0 +1,256 @@
+import { html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { $ } from '@mdui/jq/$.js';
+import '@mdui/jq/methods/find.js';
+import '@mdui/jq/methods/get.js';
+import { isString } from '@mdui/jq/shared/helper.js';
+import { MduiElement } from '@mdui/shared/base/mdui-element.js';
+import { DefinedController } from '@mdui/shared/controllers/defined.js';
+import { watch } from '@mdui/shared/decorators/watch.js';
+import { arraysEqualIgnoreOrder } from '@mdui/shared/helpers/array.js';
+import { booleanConverter } from '@mdui/shared/helpers/decorator.js';
+import { componentStyle } from '@mdui/shared/lit-styles/component-style.js';
+import { imageSelectGroupStyle } from './image-select-group-style.js';
+import type { ImageSelect as ImageSelectOriginal } from './index.js';
+import type { CSSResultGroup, TemplateResult } from 'lit';
+
+type ImageSelect = ImageSelectOriginal & {
+  selected: boolean;
+  groupDisabled: boolean;
+};
+
+/**
+ * @summary 图片选择组组件。需配合 `<mdui-image-select>` 组件使用
+ *
+ * ```html
+ * <mdui-image-select-group selects="multiple">
+ * ..<mdui-image-select src="image1.jpg" value="1"></mdui-image-select>
+ * ..<mdui-image-select src="image2.jpg" value="2"></mdui-image-select>
+ * ..<mdui-image-select src="image3.jpg" value="3"></mdui-image-select>
+ * </mdui-image-select-group>
+ * ```
+ *
+ * @event change - 选中的值变更时触发
+ *
+ * @slot - `<mdui-image-select>` 组件
+ *
+ * @cssprop --columns - 网格列数。默认为 `3`
+ * @cssprop --gap - 网格间距。默认为 `0.5rem`
+ */
+@customElement('mdui-image-select-group')
+export class ImageSelectGroup extends MduiElement<ImageSelectGroupEventMap> {
+  public static override styles: CSSResultGroup = [
+    componentStyle,
+    imageSelectGroupStyle,
+  ];
+
+  /**
+   * 选择模式。可选值包括：
+   *
+   * * `single`：单选
+   * * `multiple`：多选
+   */
+  @property({ reflect: true })
+  // eslint-disable-next-line prettier/prettier
+  public selects:
+    | /*单选*/ 'single'
+    | /*多选*/ 'multiple' = 'multiple';
+
+  /**
+   * 是否为禁用状态
+   */
+  @property({
+    type: Boolean,
+    reflect: true,
+    converter: booleanConverter,
+  })
+  public disabled = false;
+
+  /**
+   * 当前选中的 `<mdui-image-select>` 的值。
+   *
+   * 在 `selects="single"` 时为字符串，在 `selects="multiple"` 时为字符串数组。
+   */
+  @property()
+  public value: string | string[] = '';
+
+  @state()
+  private selectedValues: string[] = [];
+
+  // 是否为初始状态，初始状态不触发 change 事件
+  private isInitial = true;
+
+  private readonly definedController = new DefinedController(this, {
+    relatedElements: ['mdui-image-select'],
+  });
+
+  // 为了使 <mdui-image-select> 可以不是该组件的直接子元素
+  private get items() {
+    return $(this)
+      .find('mdui-image-select')
+      .get() as unknown as ImageSelect[];
+  }
+
+  private get itemsEnabled() {
+    return $(this)
+      .find('mdui-image-select:not([disabled])')
+      .get() as unknown as ImageSelect[];
+  }
+
+  private get isSingle() {
+    return this.selects === 'single';
+  }
+
+  private get isMultiple() {
+    return this.selects === 'multiple';
+  }
+
+  @watch('selects', true)
+  private async onSelectsChange() {
+    if (this.isSingle && this.selectedValues.length > 1) {
+      this.setSelectedValues(this.selectedValues.slice(0, 1));
+    }
+
+    await this.onSelectedValuesChange();
+  }
+
+  @watch('selectedValues', true)
+  private async onSelectedValuesChange() {
+    await this.definedController.whenDefined();
+
+    const value = this.isMultiple
+      ? this.selectedValues
+      : this.selectedValues[0] || '';
+
+    this.setValue(value);
+
+    if (!this.isInitial) {
+      this.emit('change');
+    }
+  }
+
+  @watch('value')
+  private async onValueChange() {
+    this.isInitial = !this.hasUpdated;
+    await this.definedController.whenDefined();
+
+    const values = (
+      this.isSingle
+        ? [this.value as string]
+        : isString(this.value)
+          ? this.value
+            ? [this.value]
+            : []
+          : this.value
+    ).filter((i) => i);
+
+    this.setSelectedValues(values);
+    this.updateItems();
+  }
+
+  @watch('disabled')
+  private async onDisabledChange() {
+    await this.definedController.whenDefined();
+    this.updateItems();
+  }
+
+  public override connectedCallback() {
+    super.connectedCallback();
+
+    this.value =
+      this.isMultiple && isString(this.value)
+        ? this.value
+          ? [this.value]
+          : []
+        : this.value;
+  }
+
+  protected override render(): TemplateResult {
+    return html`<slot
+      @slotchange=${this.onSlotChange}
+      @click=${this.onClick}
+    ></slot>`;
+  }
+
+  private selectOne(item: ImageSelect) {
+    if (this.isMultiple) {
+      const values = [...this.selectedValues];
+      if (values.includes(item.value)) {
+        values.splice(values.indexOf(item.value), 1);
+      } else {
+        values.push(item.value);
+      }
+      this.setSelectedValues(values);
+    }
+
+    if (this.isSingle) {
+      if (this.selectedValues.includes(item.value)) {
+        this.setSelectedValues([]);
+      } else {
+        this.setSelectedValues([item.value]);
+      }
+    }
+
+    this.isInitial = false;
+    this.updateItems();
+  }
+
+  private async onClick(event: MouseEvent) {
+    if (event.button) {
+      return;
+    }
+
+    await this.definedController.whenDefined();
+
+    const target = event.target as HTMLElement;
+    const item = target.closest(
+      'mdui-image-select',
+    ) as ImageSelect | null;
+
+    if (!item || item.disabled || item.groupDisabled) {
+      return;
+    }
+
+    if (item.value) {
+      this.selectOne(item);
+    }
+  }
+
+  private async onSlotChange() {
+    await this.definedController.whenDefined();
+    this.updateItems();
+  }
+
+  private setSelectedValues(values: string[]): void {
+    if (!arraysEqualIgnoreOrder(this.selectedValues, values)) {
+      this.selectedValues = values;
+    }
+  }
+
+  private setValue(value: string | string[]): void {
+    if (this.isSingle) {
+      this.value = value;
+    } else if (
+      !arraysEqualIgnoreOrder(this.value as string[], value as string[])
+    ) {
+      this.value = value;
+    }
+  }
+
+  private updateItems() {
+    this.items.forEach((item) => {
+      item.groupDisabled = this.disabled;
+      item.selected = this.selectedValues.includes(item.value);
+    });
+  }
+}
+
+export interface ImageSelectGroupEventMap {
+  change: CustomEvent<void>;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'mdui-image-select-group': ImageSelectGroup;
+  }
+}

--- a/packages/mdui/src/components/image-select/index.ts
+++ b/packages/mdui/src/components/image-select/index.ts
@@ -1,0 +1,188 @@
+import { html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { styleMap } from 'lit/directives/style-map.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+import { MduiElement } from '@mdui/shared/base/mdui-element.js';
+import { HasSlotController } from '@mdui/shared/controllers/has-slot.js';
+import { booleanConverter } from '@mdui/shared/helpers/decorator.js';
+import { nothingTemplate } from '@mdui/shared/helpers/template.js';
+import { componentStyle } from '@mdui/shared/lit-styles/component-style.js';
+import { FocusableMixin } from '@mdui/shared/mixins/focusable.js';
+import '@mdui/shared/icons/check-circle.js';
+import { RippleMixin } from '../ripple/ripple-mixin.js';
+import { style } from './style.js';
+import type { Ripple } from '../ripple/index.js';
+import type { CSSResultGroup, TemplateResult } from 'lit';
+import type { Ref } from 'lit/directives/ref.js';
+
+/**
+ * @summary 图片选择组件。可配合 `<mdui-image-select-group>` 组件使用
+ *
+ * ```html
+ * <mdui-image-select src="https://example.com/image.jpg" value="1"></mdui-image-select>
+ * ```
+ *
+ * @event focus - 获得焦点时触发
+ * @event blur - 失去焦点时触发
+ * @event change - 选中状态变更时触发
+ *
+ * @slot - 自定义图片内容，可以为 `<img>` 元素或其他内容
+ *
+ * @csspart image - 组件内部的 `<img>` 元素
+ * @csspart indicator - 选中状态的指示器图标
+ *
+ * @cssprop --shape-corner - 组件的圆角大小。可以指定一个具体的像素值；但更推荐引用设计令牌
+ */
+@customElement('mdui-image-select')
+export class ImageSelect extends RippleMixin(
+  FocusableMixin(MduiElement),
+)<ImageSelectEventMap> {
+  public static override styles: CSSResultGroup = [componentStyle, style];
+
+  /**
+   * 图片的 URL 地址
+   */
+  @property({ reflect: true })
+  public src?: string;
+
+  /**
+   * 图片的替代文本描述
+   */
+  @property({ reflect: true })
+  public alt?: string;
+
+  /**
+   * 图片如何适应容器框，与原生的 `object-fit` 属性相同。可选值包括：
+   *
+   * * `contain`：保持图片原有尺寸比例，内容会被等比例缩放
+   * * `cover`：保持图片原有尺寸比例，但部分内容可能被剪切
+   * * `fill`：不保持图片原有尺寸比例，内容会被拉伸以填充整个容器
+   * * `none`：保留图片原有尺寸，内容不会被缩放或拉伸
+   * * `scale-down`：保持图片原有尺寸比例，内容尺寸与 `none` 或 `contain` 中较小的一个相同
+   */
+  @property({ reflect: true })
+  public fit?:
+    | /*保持图片原有尺寸比例，内容会被等比例缩放*/ 'contain'
+    | /*保持图片原有尺寸比例，但部分内容可能被剪切*/ 'cover'
+    | /*不保持图片原有尺寸比例，内容会被拉伸以填充整个容器*/ 'fill'
+    | /*保留图片原有尺寸，内容不会被缩放或拉伸*/ 'none'
+    | /*保持图片原有尺寸比例，内容尺寸与 `none` 或 `contain` 中较小的一个相同*/ 'scale-down';
+
+  /**
+   * 是否为选中状态
+   */
+  @property({
+    type: Boolean,
+    reflect: true,
+    converter: booleanConverter,
+  })
+  public selected = false;
+
+  /**
+   * 是否为禁用状态
+   */
+  @property({
+    type: Boolean,
+    reflect: true,
+    converter: booleanConverter,
+  })
+  public disabled = false;
+
+  /**
+   * 图片选择的值，将被 `<mdui-image-select-group>` 使用
+   */
+  @property({ reflect: true })
+  public value = '';
+
+  /**
+   * 是否被 group 组件禁用（内部使用）
+   */
+  @property({
+    type: Boolean,
+    reflect: true,
+    converter: booleanConverter,
+    attribute: 'group-disabled',
+  })
+  public groupDisabled = false;
+
+  private readonly rippleRef: Ref<Ripple> = createRef();
+  private readonly hasSlotController = new HasSlotController(this, '[default]');
+
+  protected override get rippleElement() {
+    return this.rippleRef.value!;
+  }
+
+  protected override get rippleDisabled(): boolean {
+    return this.disabled || this.groupDisabled;
+  }
+
+  protected override get focusElement(): HTMLElement {
+    return this;
+  }
+
+  protected override get focusDisabled(): boolean {
+    return this.disabled || this.groupDisabled;
+  }
+
+  public override connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('click', this.onClick);
+  }
+
+  public override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('click', this.onClick);
+  }
+
+  protected override render(): TemplateResult {
+    return html`<mdui-ripple
+        ${ref(this.rippleRef)}
+        .noRipple=${this.noRipple}
+      ></mdui-ripple>
+      <div class="content">
+        ${this.hasSlotController.test('[default]')
+          ? html`<slot></slot>`
+          : this.src
+            ? html`<img
+                part="image"
+                alt=${ifDefined(this.alt)}
+                src=${this.src}
+                style=${styleMap({ objectFit: this.fit ?? 'cover' })}
+              />`
+            : nothingTemplate}
+      </div>
+      <div class="indicator" part="indicator">
+        <mdui-icon-check-circle></mdui-icon-check-circle>
+      </div>`;
+  }
+
+  /**
+   * 仅在非 group 内使用时，自行切换选中状态
+   */
+  private readonly onClick = () => {
+    if (this.disabled || this.groupDisabled) {
+      return;
+    }
+
+    // 在 group 中时，由 group 管理选中状态
+    if (this.closest('mdui-image-select-group')) {
+      return;
+    }
+
+    this.selected = !this.selected;
+    this.emit('change');
+  };
+}
+
+export interface ImageSelectEventMap {
+  focus: FocusEvent;
+  blur: FocusEvent;
+  change: CustomEvent<void>;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'mdui-image-select': ImageSelect;
+  }
+}

--- a/packages/mdui/src/components/image-select/style.less
+++ b/packages/mdui/src/components/image-select/style.less
@@ -1,0 +1,78 @@
+:host {
+  --shape-corner: var(--mdui-shape-corner-medium);
+
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  border-radius: var(--shape-corner);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  .border(3px, solid, surface, 1, border);
+  .transition(border-color, short4, standard);
+  .state-layer-color(on-surface);
+}
+
+:host([selected]:not([selected="false" i])) {
+  .border-color(primary);
+  .state-layer-color(primary);
+
+  .indicator {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+:host([disabled]:not([disabled="false" i])),
+:host([group-disabled]:not([group-disabled="false" i])) {
+  opacity: 0.38;
+  cursor: default;
+  pointer-events: none;
+}
+
+.content {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: calc(var(--shape-corner) - 3px);
+}
+
+img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+::slotted(img) {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.indicator {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  .top(8);
+  .left(8);
+  .width(24);
+  .height(24);
+  border-radius: 50%;
+  .background-color(primary);
+  .color(on-primary);
+  opacity: 0;
+  transform: scale(0.5);
+  transition-property: opacity, transform;
+  .transition-duration(short4);
+  .transition-timing-function(standard);
+  pointer-events: none;
+  z-index: 1;
+
+  mdui-icon-check-circle {
+    .width(24);
+    .height(24);
+  }
+}

--- a/packages/mdui/src/components/image-select/style.less
+++ b/packages/mdui/src/components/image-select/style.less
@@ -12,8 +12,8 @@
   .state-layer-color(on-surface);
 }
 
-:host([selected]:not([selected="false" i])) {
-  .border-color(primary);
+:host([selected]:not([selected='false' i])) {
+  .border(3px, solid, primary) !important;
   .state-layer-color(primary);
 
   .indicator {
@@ -22,8 +22,8 @@
   }
 }
 
-:host([disabled]:not([disabled="false" i])),
-:host([group-disabled]:not([group-disabled="false" i])) {
+:host([disabled]:not([disabled='false' i])),
+:host([group-disabled]:not([group-disabled='false' i])) {
   opacity: 0.38;
   cursor: default;
   pointer-events: none;

--- a/packages/mdui/src/mdui.ts
+++ b/packages/mdui/src/mdui.ts
@@ -16,6 +16,8 @@ export * from './components/divider.js';
 export * from './components/dropdown.js';
 export * from './components/fab.js';
 export * from './components/icon.js';
+export * from './components/image-select.js';
+export * from './components/image-select-group.js';
 export * from './components/layout.js';
 export * from './components/layout-item.js';
 export * from './components/layout-main.js';

--- a/scripts/common/build/docs.ts
+++ b/scripts/common/build/docs.ts
@@ -37,6 +37,7 @@ export const docComponents: Record<string, string[]> = {
   'bottom-app-bar': ['mdui-bottom-app-bar'],
   'top-app-bar': ['mdui-top-app-bar', 'mdui-top-app-bar-title'],
   layout: ['mdui-layout', 'mdui-layout-item', 'mdui-layout-main'],
+  'image-select': ['mdui-image-select-group', 'mdui-image-select'],
 };
 
 // vscode 和 webstorm 中的 description 如果包含链接，默认是不包含域名的，这里手动添加域名

--- a/scripts/shared/make-icons.ts
+++ b/scripts/shared/make-icons.ts
@@ -26,6 +26,7 @@ const sharedIcons = [
   'cancel--outlined',
   'visibility-off',
   'visibility',
+  'check-circle',
 ];
 
 // 字符串转驼峰，且首字母大写


### PR DESCRIPTION
This adds an `image-select` and `image-select-group` component.

These components look like this:
<img width="734" height="2087" alt="image" src="https://github.com/user-attachments/assets/908618f2-b50c-4794-b5fc-a6896092ceea" />

And can be used like this:  
```html
<mdui-image-select-group selects="multiple">
  <mdui-image-select src="https://via.placeholder.com/200" value="1"></mdui-image-select>
  <mdui-image-select src="https://via.placeholder.com/200" value="2"></mdui-image-select>
  <mdui-image-select src="https://via.placeholder.com/200" value="3"></mdui-image-select>
</mdui-image-select-group>
```

> [!CAUTION]
> **These components were generated with AI** due to time constraints at work. I found them useful for my work and thought others might benefit as well. If you have concerns about AI-generated content or do not want to review it, feel free to reject this PR, i can understand. 