### PR TITLE
fix(text-field): counter color not changing when disabled

### DIFF
--- a/packages/mdui/src/components/text-field/style.less
+++ b/packages/mdui/src/components/text-field/style.less
@@ -340,12 +340,12 @@ textarea.input {
 }
 
 :host([variant="filled"]) .label {
-  + .input {
+  +.input {
     .padding-top(22);
     .padding-bottom(6);
   }
 
-  + textarea.input {
+  +textarea.input {
     padding-top: 0;
     .margin-top(22);
   }
@@ -391,6 +391,10 @@ textarea.input {
   flex-wrap: nowrap;
   .padding-left(16);
   .typescale(body-small);
+
+  :host([disabled]:not([disabled="false" i])) & {
+    .color(on-surface, 38%);
+  }
 }
 
 // edge 中会默认添加密码切换按钮，隐藏掉


### PR DESCRIPTION
fix #410
从状态的角度讲的确应该把counter的颜色置灰，像helper那样