### PR TITLE
fix(tooltip): don't crash if element is removed from dom before close

### DIFF
--- a/packages/mdui/src/components/tooltip/index.ts
+++ b/packages/mdui/src/components/tooltip/index.ts
@@ -276,7 +276,10 @@ export class Tooltip extends MduiElement<TooltipEventMap> {
         [{ transform: 'scale(1)' }, { transform: 'scale(0)' }],
         { duration, easing },
       );
-      this.popupRef.value!.hidden = true;
+      const refVal = this.popupRef.value;
+      if (refVal) {
+        refVal!.hidden = true;
+      }
       this.emit('closed');
     }
   }


### PR DESCRIPTION
Fixes #375

In my case, it happens when a Tooltip is removed from the DOM _while being displayed_
i.e. a button's action causes a React re-render which no longer includes the tooltip element.

e.g.
```jsx
function Component() {
    const [visible, setVisible] = useState(true);
    let content;

    if (visible) {
        content = (<mdui-tooltip trigger="focus" content="Service List">
                    <mdui-button-icon icon="queue_music"
                                 onClick={() => setVisible(false)}></mdui-button-icon>
                   </mdui-tooltip>);
    }

    return content;
}

```

1. use Tab to focus the button
2. press enter
3. crash